### PR TITLE
Head orientation improvements

### DIFF
--- a/HC_VRTrial/VRUtils/VRCamera.cs
+++ b/HC_VRTrial/VRUtils/VRCamera.cs
@@ -32,7 +32,12 @@ namespace HC_VRTrial.VRUtils
             // Set the current position and rotation of the head as the base head.
             HasBaseHead = true;
             BaseHeadPosition = vrCamera.transform.localPosition;
-            BaseHeadRotation = vrCamera.transform.localRotation;
+
+            // Ignore the local X and Z components of the rotation - they will be affected by HMD tilt when starting the game
+            // For example, if starting the game with a tilted headset, the user will need to maintain the tilt to play, 
+            // which is uncomfortable.
+            Vector3 baseRotEuler = vrCamera.transform.localRotation.eulerAngles;
+            BaseHeadRotation = Quaternion.Euler(0, baseRotEuler.y, 0);
         }
 
         private int Depth { get; set; }

--- a/HC_VRTrial/VRUtils/VRCamera.cs
+++ b/HC_VRTrial/VRUtils/VRCamera.cs
@@ -85,5 +85,17 @@ namespace HC_VRTrial.VRUtils
 
             Normal.depth = Depth;
         }
+
+        public void Update()
+        {
+            // Remove X and Z components from the camera parent
+            // This is done as the camera is often tilted, and can be freely manipulated in some scenes.
+            // This is very nauseating, especially if you try to look around
+            Vector3 cameraParentRotEuler = transform.parent.rotation.eulerAngles;
+            cameraParentRotEuler.x = 0;
+            cameraParentRotEuler.z = 0;
+
+            transform.parent.rotation = Quaternion.Euler(cameraParentRotEuler);
+        }
     }
 }


### PR DESCRIPTION
This PR makes 2 changes that should improve comfort:
1. Base head rotation setup is modified so that X and Z components are ignored. These are responsible for tilt. I believe that ignoring them is a good choice, as VR environments should always have a level floor. Y component is kept as the "heading direction".

2. In Update(), reset the XZ components of the camera parent. This resets the default camera tilt used in many scenes. The motivation behind this change is the same as previous. Unfortunately, this is not perfect - if panning the camera quickly (in H scenes), there will be one-frame delay before the rotation is reset. I believe this is because the game modifies the camera position after the patch overrides it. The better way would be to change script execution order, or use Application.onBeforeRender, but I believe this currently can't be done with IL2CPP.

With these 2 changes, the floor of the game world always matches with reality, which makes it a lot less nauseating to play. I have tested it for some time and I believe it works well. Please consider looking through my PR.

Thank you for your hard work on this!